### PR TITLE
Add --dir arg to support building pakages that are not in the root

### DIFF
--- a/npm-publish-git
+++ b/npm-publish-git
@@ -6,6 +6,7 @@ set -euo pipefail
 ## Publish an NPM package to git tag.
 ##
 ##   --tag TAG      Use specific dist tag. "X.Y.Z" will be replaced with the current version
+##   --dir DIR      Publish the package in the specified subdirectory
 ##
 ##   -h, --help     Display this help and exit
 ##   -v, --version  Output version information and exit
@@ -46,6 +47,10 @@ while [[ $# -gt 0 ]]; do
         --tag)
             CUSTOM_TAG=true
             VSN_DIST_TAG="${2/X.Y.Z/${VSN}}"
+            shift 2
+            ;;
+        --dir)
+            CUSTOM_DIR=$2
             shift 2
             ;;
         -h|--help)
@@ -99,7 +104,12 @@ function on_exit() {
 
 trap on_exit EXIT
 
-TARBALL=$(npm pack | tail -1)
+TARBALL=$(if [ -n "$CUSTOM_DIR" ]; then cd "$CUSTOM_DIR"; fi; npm pack | tail -1)
+if [ -n "$CUSTOM_DIR" ]
+then
+    mv "$CUSTOM_DIR/$TARBALL" "$TARBALL"
+fi
+
 ${DIR}/package.json-publish > published.package.json
 
 ls -A | grep -v -e "^${TARBALL}\$" -e "^.git$" -e "^published.package.json$" | xargs rm -rf

--- a/npm-publish-git
+++ b/npm-publish-git
@@ -108,9 +108,13 @@ TARBALL=$(if [ -n "$CUSTOM_DIR" ]; then cd "$CUSTOM_DIR"; fi; npm pack | tail -1
 if [ -n "$CUSTOM_DIR" ]
 then
     mv "$CUSTOM_DIR/$TARBALL" "$TARBALL"
+    (
+        cd "$CUSTOM_DIR"
+        ${DIR}/package.json-publish
+    ) > published.package.json
+else
+    ${DIR}/package.json-publish > published.package.json
 fi
-
-${DIR}/package.json-publish > published.package.json
 
 ls -A | grep -v -e "^${TARBALL}\$" -e "^.git$" -e "^published.package.json$" | xargs rm -rf
 tar -xf ${TARBALL}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "npm-publish-git",
+  "name": "@hedgepigdaniel/npm-publish-git",
   "version": "0.0.10",
   "repository": {
     "type": "git",
-    "url": "git://github.com/andreineculau/npm-publish-git.git"
+    "url": "git://github.com/hedgepigdaniel/npm-publish-git.git"
   },
   "author": "Andrei Neculau",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "license": "Apache-2.0",
   "bin": {
     "npm-publish-git": "./npm-publish-git"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hedgepigdaniel/npm-publish-git",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/hedgepigdaniel/npm-publish-git.git"


### PR DESCRIPTION
This is useful for monorepos, where you have multiple NPM packages in subdirectories which are published separately.

### TODO
- [x] The package.json from the sub package should be published (not the root)